### PR TITLE
BSVoting Fixing bshook and auth errors

### DIFF
--- a/mods/1.37.0_9064817954/beatsavervoting-0.1.2.json
+++ b/mods/1.37.0_9064817954/beatsavervoting-0.1.2.json
@@ -1,0 +1,14 @@
+{
+  "name": "BeatSaverVoting",
+  "description": "Quest mod to allow users to vote on beatsaver",
+  "id": "beatsavervoting",
+  "version": "0.1.2",
+  "author": "RedBrumbler",
+  "authorIcon": "https://avatars.githubusercontent.com/u/51795403?v=4",
+  "modloader": "Scotland2",
+  "download": "https://github.com/lemmingllama/BeatSaverVoting.Quest/releases/download/bshook/BeatSaverVoting.qmod",
+  "source": "https://github.com/RedBrumbler/BeatSaverVoting.Quest/",
+  "cover": null,
+  "funding": [],
+  "website": null
+}


### PR DESCRIPTION
Updating BeatSaverVoting to update bshook to 5.1.9 to prevent bshook crashes, and to merge in fixes that prevent crashes when authentication errors occur.