### PR TITLE
Create BSMapLoader-0.2.0.json

### DIFF
--- a/mods/1.40.8_7379/BSMapLoader-0.2.0.json
+++ b/mods/1.40.8_7379/BSMapLoader-0.2.0.json
@@ -1,0 +1,15 @@
+{
+  "name": "BSMapLoader",
+  "description": "\"A human-readable alternative to Beat Saber's v4 .dat format. Instead of editing raw JSON, write maps in plain .bsmap text files with simple keywords like NOTE, WALL, and LIGHT. Automatically converts to v4 .dat and lightshow files at startup. See https://github.com/VoidNachos/BSMapLoader for the full format guide. Requires SongCore.",
+  "id": "BSMapLoader",
+  "version": "0.2.0",
+  "author": "VoidNachos",
+  "authorIcon": "https://avatars.githubusercontent.com/u/225590723?v=4",
+  "modloader": "Scotland2",
+  "download": "https://github.com/VoidNachos/BSMapLoader/releases/download/v0.2.0/BSMapLoader.qmod",
+  "dependencies": [],
+  "source": "https://github.com/VoidNachos/BSMapLoader/",
+  "cover": null,
+  "funding": [],
+  "website": "https://github.com/VoidNachos/BSMapLoader/"
+}


### PR DESCRIPTION
It's a Beat Saber Quest mod that lets you write maps in a simple plain text format (.bsmap) instead of dealing with raw JSON. You write things like: NOTE time:10.88 column:1 row:0 color:red angle:180 LIGHT time:10.88 type:4 value:2 brightness:1.0
And the mod automatically converts it to the proper Beat Saber v4 .dat and lightshow files every time the game starts. The idea is that Beat Saber's native format is basically unreadable machine-generated JSON, so this gives mappers a much more human-friendly way to write and edit maps by hand. Also NoodleExtensions and MappingExtensions require the mod to be installed on the player's side to play maps that use them — if you don't have NE installed and someone sends you a NE map, it just won't load. BSMapLoader is different — it's purely a conversion tool that runs at startup. The output is standard v4 .dat files that any vanilla SongCore installation can load. The player never needs BSMapLoader installed, only the mapper does.