### PR TITLE
Create discordrichpresence-0.1.0.json

### DIFF
--- a/mods/1.40.8_7379/discordrichpresence-0.1.0.json
+++ b/mods/1.40.8_7379/discordrichpresence-0.1.0.json
@@ -1,0 +1,15 @@
+{
+  "name": "Discord Rich Presence",
+  "description": "A Beat Saber Quest mod for displaying stats on Discord",
+  "id": "discordrichpresence",
+  "version": "0.1.0",
+  "author": "Jess",
+  "authorIcon": "https://avatars.githubusercontent.com/u/62964686?v=4",
+  "modloader": "Scotland2",
+  "download": "https://github.com/RainzDev/BSQ_DiscordRichPresence/releases/download/1.40.8/DiscordRichPresense.qmod",
+  "dependencies": [],
+  "source": "https://github.com/RainzDev/BSQ_DiscordRichPresence/",
+  "cover": null,
+  "funding": [],
+  "website": "https://github.com/RainzDev/BSQ_DiscordRichPresence/"
+}


### PR DESCRIPTION
This mod makes a Discord Rich Presence status shown on your profile using HTTP requests, which requires a local API server hosted on your PC. 