### PR TITLE
Add Keep Favorites 0.1.2 for Beat Saber 1.40.8

### DIFF
--- a/mods/1.40.8_7379/KeepFavorites-0.1.2.json
+++ b/mods/1.40.8_7379/KeepFavorites-0.1.2.json
@@ -1,0 +1,36 @@
+{
+  "name": "Keep Favorites",
+  "description": "Scans custom songs on Quest Beat Saber and deletes non-favorite song folders from an in-game UI.",
+  "id": "KeepFavorites",
+  "version": "0.1.2",
+  "author": "TigerYoo",
+  "authorIcon": "https://avatars.githubusercontent.com/u/6271133?v=4",
+  "modloader": "Scotland2",
+  "download": "https://github.com/MTGVim/beatsaber-keep-favorites/releases/download/v0.1.2/KeepFavorites.qmod",
+  "dependencies": [
+    {
+      "id": "beatsaber-hook",
+      "version": "^6.4.2"
+    },
+    {
+      "id": "bsml",
+      "version": "^0.4.55"
+    },
+    {
+      "id": "custom-types",
+      "version": "^0.18.4"
+    },
+    {
+      "id": "paper2_scotland2",
+      "version": "^4.7.0"
+    },
+    {
+      "id": "songcore",
+      "version": "^1.1.25"
+    }
+  ],
+  "source": "https://github.com/MTGVim/beatsaber-keep-favorites/",
+  "cover": "https://raw.githubusercontent.com/MTGVim/beatsaber-keep-favorites/main/assets/readme-cover.png",
+  "funding": [],
+  "website": "https://github.com/MTGVim/beatsaber-keep-favorites/"
+}


### PR DESCRIPTION
## Summary
- add `Keep Favorites` version `0.1.2` under `mods/1.40.8_7379`
- point the download field at the public GitHub release asset
- include the Quest dependencies from the published qmod manifest

## Verification
- public release asset is live: `v0.1.2/KeepFavorites.qmod`
- downloaded the public qmod and verified its embedded `mod.json`
- verified `packageVersion` is `1.40.8_7379`
- verified `modloader` is `Scotland2`
- verified source / website / cover URLs return 200

## Published mod metadata
- Repo: https://github.com/MTGVim/beatsaber-keep-favorites/
- Release: https://github.com/MTGVim/beatsaber-keep-favorites/releases/tag/v0.1.2
