### PR TITLE
QBS+ Move NoteTweaker to the right gameversion folder, fix funding links

### DIFF
--- a/mods/1.40.8_7379/qbeatsaberplus-gametweaker-6.4.5.json
+++ b/mods/1.40.8_7379/qbeatsaberplus-gametweaker-6.4.5.json
@@ -27,6 +27,6 @@
   ],
   "source": "https://github.com/hardcpp/QBeatSaberPlus-GameTweaker/",
   "cover": "https://raw.githubusercontent.com/hardcpp/QBeatSaberPlus-GameTweaker/master/cover.png",
-  "funding": [],
+  "funding": ["https://patreon.com/BeatSaberPlus"],
   "website": "https://github.com/hardcpp/QBeatSaberPlus-GameTweaker/"
 }

--- a/mods/1.40.8_7379/qbeatsaberplus-menumusic-6.4.5.json
+++ b/mods/1.40.8_7379/qbeatsaberplus-menumusic-6.4.5.json
@@ -31,6 +31,6 @@
   ],
   "source": "https://github.com/hardcpp/QBeatSaberPlus-MenuMusic/",
   "cover": "https://raw.githubusercontent.com/hardcpp/QBeatSaberPlus-MenuMusic/master/cover.png",
-  "funding": [],
+  "funding": ["https://patreon.com/BeatSaberPlus"],
   "website": "https://github.com/hardcpp/QBeatSaberPlus-MenuMusic/"
 }

--- a/mods/1.40.8_7379/qbeatsaberplus-multiplayer-6.4.5.json
+++ b/mods/1.40.8_7379/qbeatsaberplus-multiplayer-6.4.5.json
@@ -35,6 +35,6 @@
   ],
   "source": "https://github.com/hardcpp/QBeatSaberPlus-Multiplayer-Download/",
   "cover": "https://raw.githubusercontent.com/hardcpp/QBeatSaberPlus-Multiplayer-Download/main/cover.png",
-  "funding": [],
+  "funding": ["https://patreon.com/BeatSaberPlus"],
   "website": "https://github.com/hardcpp/QBeatSaberPlus-Multiplayer-Download/"
 }

--- a/mods/1.40.8_7379/qbeatsaberplus-notetweaker-6.4.5.json
+++ b/mods/1.40.8_7379/qbeatsaberplus-notetweaker-6.4.5.json
@@ -6,7 +6,7 @@
   "author": "HardCPP",
   "authorIcon": "https://avatars.githubusercontent.com/u/2964819?v=4",
   "modloader": "Scotland2",
-  "download": "https://github.com/hardcpp/QBeatSaberPlus-NoteTweaker/releases/download/v6.4.5/QBeatSaberPlus-NoteTweaker.qmod",
+  "download": "https://github.com/hardcpp/QBeatSaberPlus-NoteTweaker/releases/download/v6.4.5/QBeatSaberPlus-NoteTweaker.qmod?20260814",
   "dependencies": [
     {
       "id": "beatsaber-hook",

--- a/mods/1.40.8_7379/qbeatsaberplus-notetweaker-6.4.5.json
+++ b/mods/1.40.8_7379/qbeatsaberplus-notetweaker-6.4.5.json
@@ -27,6 +27,6 @@
   ],
   "source": "https://github.com/hardcpp/QBeatSaberPlus-NoteTweaker/",
   "cover": "https://raw.githubusercontent.com/hardcpp/QBeatSaberPlus-NoteTweaker/master/cover.png",
-  "funding": [],
+  "funding": ["https://patreon.com/BeatSaberPlus"],
   "website": "https://github.com/hardcpp/QBeatSaberPlus-NoteTweaker/"
 }


### PR DESCRIPTION
The NoteTweaker mod was initially published with the wrong game version