### PR TITLE
Add Nexora mod configuration file

### DIFF
--- a/mods/1.40.8_7379/nexora-2.0.0-rc.2.json
+++ b/mods/1.40.8_7379/nexora-2.0.0-rc.2.json
@@ -1,0 +1,15 @@
+{
+  "name": "Nexora",
+  "description": "Nexora uses 360° video to bring complex pre-rendered worlds to Beat Saber on Quest without rendering the full environment in real time. Nexora - Giving Depth to 360 Video.",
+  "id": "nexora",
+  "version": "2.0.0-rc.2",
+  "author": "Liam Sitbon",
+  "authorIcon": "https://avatars.githubusercontent.com/u/181689811?v=4",
+  "modloader": "Scotland2",
+  "download": "https://github.com/Liamsitbon/star-trash-tries-/releases/download/nexora-quest-2.0.0-rc.2-custom-video/Nexora-Quest-2.0.0-rc.2.qmod",
+  "dependencies": [],
+  "source": "https://github.com/Liamsitbon/star-trash-tries-/",
+  "cover": "https://raw.githubusercontent.com/Liamsitbon/star-trash-tries-/main/.github/Nexora/Nexora_Banner.png",
+  "funding": [],
+  "website": null
+}


### PR DESCRIPTION
Adds Nexora to BSQMods for Beat Saber on Quest.
Nexora uses 360° video, depth, and parallax to create complex pre-rendered environments without rendering the full world in real time.

Nexora is an original mod created by me and is not a port.

I also plan to submit separate pull requests for my Vivify Quest port and NE-Vivify Fixes after I finish reviewing the licenses for the original projects.