### PR TITLE
Create vivify-0.6.13.json for Vivify Quest mod

### DIFF
--- a/mods/1.40.8_7379/vivify-0.6.13.json
+++ b/mods/1.40.8_7379/vivify-0.6.13.json
@@ -1,0 +1,15 @@
+{
+  "name": "Vivify (Quest Port)",
+  "description": "Vivify Quest port with optional SongCore capability interoperability, synchronized animation, XR multiview post-processing and safe lifecycle ownership.\n(Credit For Aeroluna For The Vivify Mod)",
+  "id": "vivify",
+  "version": "0.6.13",
+  "author": "Liamsitbon, Vendrix, Braxed ,Aeroluna",
+  "authorIcon": "https://avatars.githubusercontent.com/u/181689811?v=4",
+  "modloader": "Scotland2",
+  "download": "https://github.com/Liamsitbon/star-trash-tries-/releases/download/quest-mods-2026-09-09-note-compat-rc2/Vivify-Quest-0.6.13.qmod",
+  "dependencies": [],
+  "source": "https://github.com/Liamsitbon/star-trash-tries-/",
+  "cover": "https://raw.githubusercontent.com/Liamsitbon/star-trash-tries-/main/.github/Vivify/Vivify_Banner.png",
+  "funding": [],
+  "website": "https://github.com/Liamsitbon/star-trash-tries-/"
+}


### PR DESCRIPTION
Adds my Vivify Quest port to BSQMods.

This ports Vivify to Beat Saber on Quest, allowing maps that use Vivify to run their custom environments, assets, effects, sabers, notes, and other visuals on Quest.

This is a Quest port of the original Vivify by Aeroluna, not the original mod. The original project is MIT licensed and the original authors are credited.